### PR TITLE
Fix ImportError for OpportunityItem in items.py

### DIFF
--- a/deep_research/komkom_scraper/komkom_scraper/items.py
+++ b/deep_research/komkom_scraper/komkom_scraper/items.py
@@ -1,1 +1,12 @@
-from deep_research.items import OpportunityItem as OpportunityItem
+import scrapy
+
+class OpportunityItem(scrapy.Item):
+    title = scrapy.Field()
+    description = scrapy.Field()
+    url = scrapy.Field()
+    source = scrapy.Field()
+    opportunity_type = scrapy.Field()
+    eligibility_criteria = scrapy.Field()
+    application_deadline = scrapy.Field()
+    publication_date = scrapy.Field()
+    # Ajoutez ici tout autre champ nécessaire selon votre usage.


### PR DESCRIPTION
This pull request addresses the ModuleNotFoundError encountered in the Docker container for the komkom_scraper spider. The error arose due to an invalid import statement in the `deep_research/komkom_scraper/komkom_scraper/items.py` file which attempted to import `OpportunityItem` from a non-existent module path within the Docker context.

### Changes made:
- Removed the problematic import statement:
  ```python
  from deep_research.items import OpportunityItem as OpportunityItem
  ```
- Defined the `OpportunityItem` class directly in the `items.py` file, inheriting from `scrapy.Item` and added the relevant fields for the scraper:
  ```python
  import scrapy
  
  class OpportunityItem(scrapy.Item):
      title = scrapy.Field()
      description = scrapy.Field()
      url = scrapy.Field()
      source = scrapy.Field()
      opportunity_type = scrapy.Field()
      eligibility_criteria = scrapy.Field()
      application_deadline = scrapy.Field()
      publication_date = scrapy.Field()
      # Add any other necessary fields as needed.
  ```
- This change ensures that the `OpportunityItem` can be instantiated without import errors in the container environment. 

### Next Steps:
Please run the end-to-end test script to validate the changes:
```bash
bash scripts/run_local_e2e.sh
```

---

> This pull request was co-created with Cosine Genie

Original Task: [komkom_news_auto_pm/zxlumy5itys2](https://cosine.sh/ifjbm46juh2l/komkom_news_auto_pm/task/zxlumy5itys2)
Author: Fallou Mbengue
