### PR TITLE
Fix ModuleNotFoundError for Middlewares and Pipelines in Docker

### DIFF
--- a/deep_research/komkom_scraper/komkom_scraper/settings.py
+++ b/deep_research/komkom_scraper/komkom_scraper/settings.py
@@ -8,11 +8,11 @@ DOWNLOAD_DELAY = 1
 AUTOTHROTTLE_ENABLED = True
 
 ITEM_PIPELINES = {
-    "deep_research.pipelines.PostgresUpsertPipeline": 300,
+    "komkom_scraper.pipelines.PostgresUpsertPipeline": 300,
 }
 
 DOWNLOADER_MIDDLEWARES = {
-    "deep_research.spiders.user_agent_rotation.UserAgentRotationMiddleware": 400,
+    "komkom_scraper.spiders.user_agent_rotation.UserAgentRotationMiddleware": 400,
 }
 
 ROBOTSTXT_OBEY = False


### PR DESCRIPTION
This pull request addresses the ModuleNotFoundError encountered when loading middlewares and pipelines within the Docker container for the Scrapy spider. The modifications made in `deep_research/komkom_scraper/komkom_scraper/settings.py` involve updating the references in the `ITEM_PIPELINES` and `DOWNLOADER_MIDDLEWARES` dictionaries.

The changes involve replacing the absolute module paths that begin with `deep_research.komkom_scraper.` with relative paths starting with `komkom_scraper.`. This ensures that the modules can be correctly located in the isolated environment of the Docker container.

The following updates were made:
- In `ITEM_PIPELINES`, changed from `'deep_research.pipelines.PostgresUpsertPipeline': 300` to `'komkom_scraper.pipelines.PostgresUpsertPipeline': 300`.
- In `DOWNLOADER_MIDDLEWARES`, changed from `'deep_research.spiders.user_agent_rotation.UserAgentRotationMiddleware': 400` to `'komkom_scraper.spiders.user_agent_rotation.UserAgentRotationMiddleware': 400`.

After merging, it is recommended to run the full end-to-end script using the command `bash scripts/run_local_e2e.sh` for validation.

---

> This pull request was co-created with Cosine Genie

Original Task: [komkom_news_auto_pm/gbww7nma7kqz](https://cosine.sh/ifjbm46juh2l/komkom_news_auto_pm/task/gbww7nma7kqz)
Author: Fallou Mbengue

## Summary by Sourcery

Fix import paths for Scrapy pipelines and middlewares to prevent ModuleNotFoundError in Docker environment

Bug Fixes:
- Use "komkom_scraper.pipelines.PostgresUpsertPipeline" instead of the old absolute path for ITEM_PIPELINES
- Use "komkom_scraper.spiders.user_agent_rotation.UserAgentRotationMiddleware" instead of the old absolute path for DOWNLOADER_MIDDLEWARES