### PR TITLE
Fix Makefile for migrate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ crawl:
 	scrapy crawl generic_opportunity
 
 migrate:
-	python -m deep_research.db
+	python -m deep_research.komkom_scraper.komkom_scraper.db
 
 test:
 	pytest tests


### PR DESCRIPTION
This pull request updates the Makefile to correct the path for the `make migrate` command. The `db.py` module has been relocated from `deep_research/db.py` to `deep_research/komkom_scraper/komkom_scraper/db/db.py`, resulting in a `ModuleNotFoundError`. The `migrate` command in the Makefile has been modified to reflect this new structure:

From:
```make
migrate:
	python -m deep_research.db
```
To:
```make
migrate:
	python -m deep_research.komkom_scraper.komkom_scraper.db
```

Additionally, it is confirmed that the `PYTHONPATH` is properly set by the `run_local_e2e.sh` script, allowing the new path to be resolved correctly from the repository root. This change will enable successful execution of the `make migrate` command.

---

> This pull request was co-created with Cosine Genie

Original Task: [komkom_news_auto_pm/x7e2sorlzf2k](https://cosine.sh/ifjbm46juh2l/komkom_news_auto_pm/task/x7e2sorlzf2k)
Author: Fallou Mbengue

## Summary by Sourcery

Bug Fixes:
- Correct the module path for the `make migrate` command to reflect the relocated `db.py` file