### PR TITLE
Fix Makefile to Target db.py for Migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ crawl:
 	scrapy crawl generic_opportunity
 
 migrate:
-	python -m deep_research.komkom_scraper.komkom_scraper.db
+	python -m deep_research.komkom_scraper.komkom_scraper.db.db
 
 test:
 	pytest tests


### PR DESCRIPTION
This pull request updates the Makefile to correctly target the `db.py` file during the migration process. The previous command attempted to execute a package instead of the specific Python file, leading to the error: 'No module named ...db.__main__'. The change modifies the `migrate` target from `python -m deep_research.komkom_scraper.komkom_scraper.db` to `python -m deep_research.komkom_scraper.komkom_scraper.db.db`, allowing for the correct execution of the migration script. After the modification, running the migration should proceed without errors. Please run the complete end-to-end script for validation: `bash scripts/run_local_e2e.sh`.

---

> This pull request was co-created with Cosine Genie

Original Task: [komkom_news_auto_pm/1tb332dixtar](https://cosine.sh/ifjbm46juh2l/komkom_news_auto_pm/task/1tb332dixtar)
Author: Fallou Mbengue

## Summary by Sourcery

Bug Fixes:
- Correct the `migrate` target in Makefile to use `python -m deep_research.komkom_scraper.komkom_scraper.db.db`, resolving the module not found error.