### PR TITLE
Update DB_HOST to host.docker.internal in run_local_e2e.sh

### DIFF
--- a/scripts/run_local_e2e.sh
+++ b/scripts/run_local_e2e.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # --- ENV VAR DEFAULTS (IMPORTANT: Assurez-vous que ces valeurs correspondent à votre configuration PostgreSQL) ---
-# DB_HOST: Utilise 127.0.0.1 pour forcer la connexion TCP/IP et éviter les problèmes de socket UNIX.
-: "${DB_HOST:=127.0.0.1}"
+# DB_HOST: Utilise host.docker.internal pour une meilleure compatibilité avec Docker Desktop (macOS/Windows).
+: "${DB_HOST:=host.docker.internal}"
 : "${DB_PORT:=5432}"
 # DB_USER: Basé sur votre capture d'écran ServerPro, l'utilisateur par défaut pour komkom_db est 'pro'.
 : "${DB_USER:=pro}"


### PR DESCRIPTION
This pull request modifies the DB_HOST variable in the `scripts/run_local_e2e.sh` file to use `host.docker.internal`. This change is made to resolve the persistent "Connection refused" issue when the script is executed from a Docker container on macOS.

### Changes:
- DB_HOST was changed from `127.0.0.1` to `host.docker.internal`, improving compatibility with Docker Desktop environments on macOS and Windows.

### Context:
PostgreSQL is verified to be running and accessible from the host machine. The issue arises specifically within Docker containers, where `127.0.0.1` does not resolve to the host correctly. This modification addresses that issue, ensuring smoother database connectivity.

### Testing:
After merging this change, please rerun the script using:
```bash
bash scripts/run_local_e2e.sh
```
This will validate that the connection issue has been resolved.

---

> This pull request was co-created with Cosine Genie

Original Task: [komkom_news_auto_pm/xhuozq24zzs6](https://cosine.sh/ifjbm46juh2l/komkom_news_auto_pm/task/xhuozq24zzs6)
Author: Fallou Mbengue

## Summary by Sourcery

Bug Fixes:
- Fix persistent “Connection refused” error when running the local E2E script inside Docker on macOS/Windows by setting DB_HOST to host.docker.internal.